### PR TITLE
Fix npm create command for npm 11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 If you're reading this README on GitHub and want to use this template, run:
 
 ```
-npm create convex@latest -- -t nextjs-convexauth
+npx create-convex@latest  -t nextjs-convexauth
 ```
 
 ## Learn more

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 If you're reading this README on GitHub and want to use this template, run:
 
 ```
-npx create-convex@latest  -t nextjs-convexauth
+npx create-convex@latest -t nextjs-convexauth
 ```
 
 ## Learn more


### PR DESCRIPTION
npm 11 broke passing through config flags with npm create.
Replaced 'npm create convex@latest --' with 'npx create-convex@latest'
and 'npm create convex --' with 'npx create-convex'.